### PR TITLE
fix: PostDetail 애니메이션 변경

### DIFF
--- a/feature/postdetail/src/main/java/com/withpeace/withpeace/feature/postdetail/navigation/PostDetailNavigation.kt
+++ b/feature/postdetail/src/main/java/com/withpeace/withpeace/feature/postdetail/navigation/PostDetailNavigation.kt
@@ -1,5 +1,7 @@
 package com.withpeace.withpeace.feature.postdetail.navigation
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -30,6 +32,12 @@ fun NavGraphBuilder.postDetailGraph(
         arguments = listOf(
             navArgument(POST_DETAIL_ID_ARGUMENT) { type = NavType.LongType },
         ),
+        enterTransition = {
+            slideIntoContainer(
+                AnimatedContentTransitionScope.SlideDirection.Left,
+                animationSpec = tween(500),
+            )
+        },
     ) {
         PostDetailRoute(
             onShowSnackBar = onShowSnackBar,


### PR DESCRIPTION
## 관련 이슈번호

<br/> close #97 


## 작업 사항
https://github.com/WithPeace/with-peace-android/issues/97#issuecomment-2089919629

[animation_after.webm](https://github.com/WithPeace/with-peace-android/assets/33768873/15534124-64a3-4f6f-93a0-b8077be697d4)

composable에 아래 애니메이션 추가
```
enterTransition = {
            slideIntoContainer(
                AnimatedContentTransitionScope.SlideDirection.Left,
                animationSpec = tween(500),
            )
        },
```


## 기타 사항

<br/>
